### PR TITLE
Add pycryptodome to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
 	license = "GPLv3",
 	platforms = ["Linux"],
 	packages = ["ldn"],
-	install_requires = ["python-netlink"]
+	install_requires = ["python-netlink", "pycryptodome"]
 )


### PR DESCRIPTION
Hi,

I just tried to install your package via pip and ran into a `ModuleNotFoundError` since it couldn't find any module named `Crypto`.

To fix this issue, I just edited `setup.py` to include `pycryptodome`.