### PR TITLE
Fix AP initialization order

### DIFF
--- a/ldn/wlan.py
+++ b/ldn/wlan.py
@@ -1602,29 +1602,6 @@ class AccessPoint(Interface):
             if message.type == nl80211.NL80211_CMD_START_AP:
                 break
 
-        if self._key is not None:
-            attrs = {
-                nl80211.NL80211_ATTR_IFINDEX: self.index(),
-                nl80211.NL80211_ATTR_KEY: {
-                    nl80211.NL80211_KEY_IDX: 1,
-                    nl80211.NL80211_KEY_DATA: self._key,
-                    nl80211.NL80211_KEY_CIPHER: WLAN_CIPHER_SUITE_CCMP
-                }
-            }
-            await self._wlan.request(nl80211.NL80211_CMD_NEW_KEY, attrs)
-
-            attrs = {
-                nl80211.NL80211_ATTR_IFINDEX: self.index(),
-                nl80211.NL80211_ATTR_KEY: {
-                    nl80211.NL80211_KEY_IDX: 1,
-                    nl80211.NL80211_KEY_DEFAULT: True,
-                    nl80211.NL80211_KEY_DEFAULT_TYPES: {
-                        nl80211.NL80211_KEY_DEFAULT_TYPE_MULTICAST: True
-                    }
-                }
-            }
-            await self._wlan.request(nl80211.NL80211_CMD_SET_KEY, attrs)
-        
         try:
             yield
         finally:
@@ -1730,19 +1707,7 @@ class AccessPoint(Interface):
             attrs[nl80211.NL80211_ATTR_STA_SUPPORTED_CHANNELS] = \
                 frame.elements[WLAN_EID_SUPPORTED_CHANNELS]
         await self._wlan.request(nl80211.NL80211_CMD_NEW_STATION, attrs)
-        
-        if self._key is not None:
-            attrs = {
-                nl80211.NL80211_ATTR_IFINDEX: self.index(),
-                nl80211.NL80211_ATTR_MAC: frame.source.encode(),
-                nl80211.NL80211_ATTR_KEY: {
-                    nl80211.NL80211_KEY_IDX: 0,
-                    nl80211.NL80211_KEY_DATA: self._key,
-                    nl80211.NL80211_KEY_CIPHER: WLAN_CIPHER_SUITE_CCMP
-                }
-            }
-            await self._wlan.request(nl80211.NL80211_CMD_NEW_KEY, attrs)
-        
+
         await self._events.put(AssociationEvent(frame.source))
         return self._create_association_response(frame.source, aid)
     

--- a/ldn/wlan.py
+++ b/ldn/wlan.py
@@ -1433,16 +1433,15 @@ class AccessPoint(Interface):
         """
         await self.up()
         self.disable_ipv6()
+        for type in [
+            IEEE80211_STYPE_ASSOC_REQ,
+            IEEE80211_STYPE_PROBE_REQ,
+            IEEE80211_STYPE_DISASSOC,
+            IEEE80211_STYPE_AUTH,
+            IEEE80211_STYPE_DEAUTH
+        ]:
+            await self._register_frame(type)
         async with self._start_ap():
-            for type in [
-                IEEE80211_STYPE_ASSOC_REQ,
-                IEEE80211_STYPE_PROBE_REQ,
-                IEEE80211_STYPE_DISASSOC,
-                IEEE80211_STYPE_AUTH,
-                IEEE80211_STYPE_DEAUTH
-            ]:
-                await self._register_frame(type)
-            
             async with util.background_task(self._process_messages):
                 yield
     

--- a/ldn/wlan.py
+++ b/ldn/wlan.py
@@ -1602,6 +1602,29 @@ class AccessPoint(Interface):
             if message.type == nl80211.NL80211_CMD_START_AP:
                 break
 
+        if self._key is not None:
+            attrs = {
+                nl80211.NL80211_ATTR_IFINDEX: self.index(),
+                nl80211.NL80211_ATTR_KEY: {
+                    nl80211.NL80211_KEY_IDX: 1,
+                    nl80211.NL80211_KEY_DATA: self._key,
+                    nl80211.NL80211_KEY_CIPHER: WLAN_CIPHER_SUITE_CCMP
+                }
+            }
+            await self._wlan.request(nl80211.NL80211_CMD_NEW_KEY, attrs)
+
+            attrs = {
+                nl80211.NL80211_ATTR_IFINDEX: self.index(),
+                nl80211.NL80211_ATTR_KEY: {
+                    nl80211.NL80211_KEY_IDX: 1,
+                    nl80211.NL80211_KEY_DEFAULT: True,
+                    nl80211.NL80211_KEY_DEFAULT_TYPES: {
+                        nl80211.NL80211_KEY_DEFAULT_TYPE_MULTICAST: True
+                    }
+                }
+            }
+            await self._wlan.request(nl80211.NL80211_CMD_SET_KEY, attrs)
+        
         try:
             yield
         finally:
@@ -1707,7 +1730,19 @@ class AccessPoint(Interface):
             attrs[nl80211.NL80211_ATTR_STA_SUPPORTED_CHANNELS] = \
                 frame.elements[WLAN_EID_SUPPORTED_CHANNELS]
         await self._wlan.request(nl80211.NL80211_CMD_NEW_STATION, attrs)
-
+        
+        if self._key is not None:
+            attrs = {
+                nl80211.NL80211_ATTR_IFINDEX: self.index(),
+                nl80211.NL80211_ATTR_MAC: frame.source.encode(),
+                nl80211.NL80211_ATTR_KEY: {
+                    nl80211.NL80211_KEY_IDX: 0,
+                    nl80211.NL80211_KEY_DATA: self._key,
+                    nl80211.NL80211_KEY_CIPHER: WLAN_CIPHER_SUITE_CCMP
+                }
+            }
+            await self._wlan.request(nl80211.NL80211_CMD_NEW_KEY, attrs)
+        
         await self._events.put(AssociationEvent(frame.source))
         return self._create_association_response(frame.source, aid)
     


### PR DESCRIPTION
## Summary

This PR fixes two issues in `AccessPoint` (`ldn/wlan.py`):

1. **Register management frame handlers before starting AP**  -- Move `NL80211_CMD_REGISTER_FRAME` calls before `NL80211_CMD_START_AP` in `AccessPoint.create()`.
2. **Remove kernel key installation**  -- Remove `NL80211_CMD_NEW_KEY` / `NL80211_CMD_SET_KEY` calls from `_start_ap()` and `_process_association_request()`.

## Problem

### Frame registration order

In the original code, management frame handlers (Auth, Assoc, Probe, etc.) are registered *after* `START_AP`. If a station sends a frame between `START_AP` and handler registration, the frame is silently dropped because no handler exists yet.

hostapd, the reference implementation, registers frames in `nl80211_setup_ap()` during mode change, *before* sending `START_AP` in `wpa_driver_nl80211_set_ap()` (see [driver_nl80211.c:6691](https://git.w1.fi/cgit/hostap/tree/src/drivers/driver_nl80211.c?id=b624b164b9#n6691) and [driver_nl80211.c:5513](https://git.w1.fi/cgit/hostap/tree/src/drivers/driver_nl80211.c?id=b624b164b9#n5513)).

### Kernel key installation

This library handles CCMP encryption and decryption in Python via monitor mode. Installing keys in the kernel via `NEW_KEY` / `SET_KEY` enables mac80211's hardware crypto offload path (see [cfg.c:498](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/mac80211/cfg.c?id=e5f0a698b3#n498)). This conflicts with the software crypto path used by this library -- both the kernel and Python would attempt to encrypt and decrypt the same frames.

In hostapd, GTK is installed after `START_AP` via `wpa_init_keys()` (see [hostapd.c:1773](https://git.w1.fi/cgit/hostap/tree/src/ap/hostapd.c?id=b624b164b9#n1773)) to support kernel hardware crypto offload. Since this library does not use kernel crypto, the keys should not be installed at all.

## Testing

Tested with `examples/host.py` on a NETGEAR A6210 (mt76x2u) adapter. The following modifications were made to the example:

- Game parameters changed to Mario Kart 8 Deluxe
- `phyname` and `phyname_monitor` set to select the correct wireless interface

Without this PR, `NL80211_CMD_NEW_KEY` in `_start_ap()` fails with `ENETDOWN`:

```
Traceback (most recent call last):
  ...
  File "ldn/wlan.py", line 1436, in create
    async with self._start_ap():
  ...
  File "ldn/wlan.py", line 1615, in _start_ap
    await self._wlan.request(nl80211.NL80211_CMD_NEW_KEY, attrs)
  ...
OSError: [Errno 100] Network is down
```

With this PR applied, the AP is created successfully and the script reaches "Listening for events."

This has only been tested on the adapter above. Please verify on other hardware as well.
